### PR TITLE
Upload build.patch for riscv64 cross build.

### DIFF
--- a/riscv64-cross-build.patch
+++ b/riscv64-cross-build.patch
@@ -1,0 +1,75 @@
+diff --git a/build_config.h b/build_config.h
+index d3cdd2db4..bd78845c3 100644
+--- a/build_config.h
++++ b/build_config.h
+@@ -124,6 +124,11 @@
+ #define ARCH_CPU_PPC64 1
+ #define ARCH_CPU_64_BITS 1
+ #define ARCH_CPU_BIG_ENDIAN 1
++#elif defined(__riscv) && (__riscv_xlen == 64)
++#define ARCH_CPU_RISCV_FAMILY 1
++#define ARCH_CPU_RISCV64 1
++#define ARCH_CPU_64_BITS 1
++#define ARCH_CPU_LITTLE_ENDIAN 1
+ #elif defined(__PPC64__)
+ #define ARCH_CPU_PPC64_FAMILY 1
+ #define ARCH_CPU_PPC64 1
+diff --git a/config/BUILDCONFIG.gn b/config/BUILDCONFIG.gn
+index f89e7e831..f65e193d1 100644
+--- a/config/BUILDCONFIG.gn
++++ b/config/BUILDCONFIG.gn
+@@ -137,7 +137,8 @@ declare_args() {
+   is_clang = current_os != "linux" ||
+              (current_cpu != "s390x" && current_cpu != "s390" &&
+               current_cpu != "ppc64" && current_cpu != "ppc" &&
+-              current_cpu != "mips" && current_cpu != "mips64")
++              current_cpu != "mips" && current_cpu != "mips64" &&
++              current_cpu != "riscv64")
+ 
+   # Allows the path to a custom target toolchain to be injected as a single
+   # argument, and set as the default toolchain.
+diff --git a/toolchain/linux/BUILD.gn b/toolchain/linux/BUILD.gn
+index fa8b17e9d..ffb35e205 100644
+--- a/toolchain/linux/BUILD.gn
++++ b/toolchain/linux/BUILD.gn
+@@ -83,6 +83,14 @@ clang_toolchain("clang_x86_v8_arm") {
+   }
+ }
+ 
++clang_toolchain("clang_x64_v8_riscv64") {
++  toolchain_args = {
++    current_cpu = "x64"
++    v8_current_cpu = "riscv64"
++    current_os = "linux"
++  }
++}
++
+ clang_toolchain("clang_x86_v8_mipsel") {
+   toolchain_args = {
+     current_cpu = "x86"
+@@ -263,6 +271,24 @@ gcc_toolchain("ppc64") {
+   }
+ }
+ 
++gcc_toolchain("riscv64") {
++  toolprefix = "riscv64-linux-gnu"
++
++  cc = "${toolprefix}-gcc"
++  cxx = "${toolprefix}-g++"
++
++  readelf = "${toolprefix}-readelf"
++  nm = "${toolprefix}-nm"
++  ar = "${toolprefix}-ar"
++  ld = cxx
++
++  toolchain_args = {
++    current_cpu = "riscv64"
++    current_os = "linux"
++    is_clang = false
++  }
++}
++
+ gcc_toolchain("mips") {
+   toolprefix = "mips-linux-gnu-"
+ 
+


### PR DESCRIPTION
This patch was in
https://github.com/v8-riscv/v8/blob/riscv-porting-dev/patches/build.patch

It got removed before upstreaming. And we still need it for
cross build for riscv64.